### PR TITLE
Explictly set get_url dest file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 
 ## [Unreleased](https://github.com/idealista/prometheus_node_exporter-role/tree/develop)
+### Fixed
+- *Explicitly set get_url dest file name*
 
 
 ## [1.2.5](https://github.com/idealista/prometheus_node_exporter-role/tree/1.2.5)

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,7 +43,7 @@
 - name: NODE_EXPORTER | Download package
   get_url:
     url: "{{ node_exporter_url }}"
-    dest: /tmp
+    dest: "/tmp/{{ node_exporter_package }}"
   when: 'node_exporter_force_reinstall or node_exporter_check|failed or "node_exporter, version {{ node_exporter_version }}" not in node_exporter_check.stdout'
 
 - name: NODE_EXPORTER | Extract package


### PR DESCRIPTION
### Requirements

None

### Description of the Change

When testing using ansible v2.4.4, get_url set the destination filename
to a UUID when it was not explicitly set causing the role to fail on the
extract.  By explicitly setting the file name in /tmp to download the
node_exporter release to the role runs cleanly under ansible 2.4.4.
This is already implemented in the prometheus_server role.

### Benefits

Role runs without failure using ansible 2.4.4

### Possible Drawbacks

None

### Applicable Issues

None
